### PR TITLE
Skip calling report function for appium integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,15 +130,16 @@ module.exports = {
     }
   },
   async afterEach (file, context) {
-    try {
-      // Go through each enabled integration and report results to it, etc.
-      print.debug('Running WebDriver integration reporting')
-      const toReport = async integration => integration.report(context)
-      await Promise.all(context.webdriver.integrations.map(toReport))
-    } catch (err) {
-      print.error(err)
+    if (!context.webdriver.appium) {
+      try {
+        // Go through each enabled integration and report results to it, etc.
+        print.debug('Running WebDriver integration reporting')
+        const toReport = async integration => integration.report(context)
+        await Promise.all(context.webdriver.integrations.map(toReport))
+      } catch (err) {
+        print.error(err)
+      }
     }
-
     try {
       if (context.testContext.browser) {
         // Tell Selenium to delete the browser session once the test is over.

--- a/index.js
+++ b/index.js
@@ -130,15 +130,17 @@ module.exports = {
     }
   },
   async afterEach (file, context) {
-    if (!context.webdriver.appium) {
-      try {
-        // Go through each enabled integration and report results to it, etc.
-        print.debug('Running WebDriver integration reporting')
-        const toReport = async integration => integration.report(context)
-        await Promise.all(context.webdriver.integrations.map(toReport))
-      } catch (err) {
-        print.error(err)
+    try {
+      // Go through each enabled integration and report results to it, etc.
+      print.debug('Running WebDriver integration reporting')
+      const toReport = async integration => {
+        if (integration.report) {
+          integration.report(context)
+        }
       }
+      await Promise.all(context.webdriver.integrations.map(toReport))
+    } catch (err) {
+      print.error(err)
     }
     try {
       if (context.testContext.browser) {

--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ module.exports = {
     } catch (err) {
       print.error(err)
     }
+
     try {
       if (context.testContext.browser) {
         // Tell Selenium to delete the browser session once the test is over.

--- a/integrations/appium.js
+++ b/integrations/appium.js
@@ -25,6 +25,4 @@ module.exports = class AppiumIntegration {
     }
     testContext.capability = Object.assign(options, testContext.capability)
   }
-
-  report () {}
 }

--- a/integrations/appium.js
+++ b/integrations/appium.js
@@ -25,4 +25,6 @@ module.exports = class AppiumIntegration {
     }
     testContext.capability = Object.assign(options, testContext.capability)
   }
+
+  report () {}
 }


### PR DESCRIPTION
integration.report is called in the afterEach() of index.js and causes the webdriver to error out if we don't either change the logic in index.js or add the function to appium.js